### PR TITLE
Add convenience wrapper for quick similarity computation

### DIFF
--- a/image.go
+++ b/image.go
@@ -1,0 +1,72 @@
+package imagehash
+
+import (
+	"fmt"
+	"image"
+
+	"github.com/vitali-fedulov/images4"
+)
+
+// Default hyper space parameters.
+const (
+	epsPct     = 0.25
+	numBuckets = 4
+)
+
+// HyperParams holds hyper space parameters for hash computations.
+type HyperParams struct {
+	epsPct     float64
+	numBuckets int
+}
+
+// Open opens and decodes an image file for a given path. It is a convenience wrapper around
+// imagehash and images4 that returns the icon and hashes.
+//
+// Takes as input a single optional params that holds epsPct and numBuckets hyper space parameters.
+func Open(path string, params ...HyperParams) (Image, error) {
+	if len(params) > 1 {
+		return Image{}, fmt.Errorf("Open() only accepts a single HyperParams as input, got %d instead", len(params))
+	}
+	eps := epsPct
+	buckets := numBuckets
+	if len(params) == 1 {
+		eps = params[0].epsPct
+		buckets = params[0].numBuckets
+	}
+
+	img, err := images4.Open(path)
+	if err != nil {
+		return Image{}, err
+	}
+	icon := images4.Icon(img)
+	centralHash := CentralHash(icon, HyperPoints10, eps, buckets)
+	hashSet := HashSet(icon, HyperPoints10, eps, buckets)
+	return Image{Image: img, Icon: icon, CentralHash: centralHash, HashSet: hashSet}, nil
+}
+
+// Image is a convenience wrapper for holding everything imagehash and images4 needs.
+//
+// Call Similar() on an Image object for quick similarity computation instead of images4.Similar().
+type Image struct {
+	Image       image.Image
+	Icon        images4.IconT
+	CentralHash uint64
+	HashSet     []uint64
+}
+
+// Similar returns true if img2 is similar to img. It is a convenience wrapper around imagehash and
+// images4 that first compares the images using CentralHash & Hashset, and then using the
+// images4.Similar() function iff there is a match between the hashes.
+//
+// It is faster than calling images4.Similar() directly for dissimilar images and
+// only slightly slower for similar images.
+func (img Image) Similar(img2 Image) bool {
+	foundSimilarImage := false
+	for _, hash := range img2.HashSet {
+		if img.CentralHash == hash {
+			foundSimilarImage = true
+			break
+		}
+	}
+	return foundSimilarImage && images4.Similar(img.Icon, img2.Icon)
+}

--- a/image.go
+++ b/image.go
@@ -2,7 +2,6 @@ package imagehash
 
 import (
 	"fmt"
-	"image"
 
 	"github.com/vitali-fedulov/images4"
 )
@@ -41,14 +40,13 @@ func Open(path string, params ...HyperParams) (Image, error) {
 	icon := images4.Icon(img)
 	centralHash := CentralHash(icon, HyperPoints10, eps, buckets)
 	hashSet := HashSet(icon, HyperPoints10, eps, buckets)
-	return Image{Image: img, Icon: icon, CentralHash: centralHash, HashSet: hashSet}, nil
+	return Image{Icon: icon, CentralHash: centralHash, HashSet: hashSet}, nil
 }
 
-// Image is a convenience wrapper for holding everything imagehash and images4 needs.
+// Image is a convenience wrapper for holding objects necessary for computing image similarity.
 //
 // Call Similar() on an Image object for quick similarity computation instead of images4.Similar().
 type Image struct {
-	Image       image.Image
 	Icon        images4.IconT
 	CentralHash uint64
 	HashSet     []uint64


### PR DESCRIPTION
Thanks for working on this, it works like a charm!

As I was using your libraries, I thought it was a low-hanging fruit to add a simple convenience wrapper around imagehash & images4, to simplify user experience. It seems to me like new `Image.Similar()` is the only thing users need from the imagehash library, so we can hide away the complexity of centralHash and hashSet.

Additionally, users could directly use the `imagehash.Image` struct to create a hashtable for quick lookup, e.g.:
```go
var images map[string]imagehash.Image
for p := range paths {
    images[p] = imagehash.Open(p)
}

func lookup(imgToLookup imagehash.Image) string {
    for p, img := range images {
        if img.Similar(imgToLookup) {
            return p
        }
    }
    return ""
}
```
LMK if you think this is a good idea and what tests you'd like me to add for them.